### PR TITLE
Fix seekbar being off center on low dpi devices

### DIFF
--- a/library/src/main/res/layout/bvp_include_controls.xml
+++ b/library/src/main/res/layout/bvp_include_controls.xml
@@ -18,7 +18,8 @@
         android:layout_toStartOf="@+id/duration"
         android:layout_toEndOf="@+id/position"
         android:layout_alignBottom="@+id/btnPlayPause"
-        android:layout_alignTop="@+id/btnPlayPause" />
+        android:layout_alignTop="@+id/btnPlayPause"
+        android:maxHeight="1000dp" />
 
     <TextView
         android:id="@+id/position"


### PR DESCRIPTION
On low DPI devices (my test devices is a Samsung Galaxy S3), the seekbar's progress circle can become off center from the progress bar of the seekbar, as seen on the screenshot. 

![screenshot_2017-02-12-15-10-00](https://cloud.githubusercontent.com/assets/12054216/22862828/5f2cbf68-f136-11e6-813e-8253206f34fb.png)


The solution to this issue is from this StackOverflow question/answer: http://stackoverflow.com/a/8329169/4465208

This fixed the issue on my device, and doesn't change how the seekbar looks on other devices.
