### PR TITLE
Bug fixes/ feature implementations.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.1'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Sep 15 17:48:03 EEST 2016
+#Mon May 01 16:23:10 BST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip

--- a/library/src/main/java/com/halilibo/bettervideoplayer/BetterVideoPlayer.java
+++ b/library/src/main/java/com/halilibo/bettervideoplayer/BetterVideoPlayer.java
@@ -867,8 +867,9 @@ public class BetterVideoPlayer extends RelativeLayout implements IUserMethods,
     // Utilities
 
     private static void LOG(String message, Object... args) {
-        if (args != null)
+        if (args != null && args.length > 0) {
             message = String.format(message, args);
+        }
         Log.d("BetterVideoPlayer", message);
     }
 

--- a/library/src/main/java/com/halilibo/bettervideoplayer/BetterVideoPlayer.java
+++ b/library/src/main/java/com/halilibo/bettervideoplayer/BetterVideoPlayer.java
@@ -655,11 +655,17 @@ public class BetterVideoPlayer extends RelativeLayout implements IUserMethods,
     @Override
     public void onBufferingUpdate(MediaPlayer mediaPlayer, int percent) {
         LOG("Buffering: %d%%", percent);
-        if (mCallback != null)
+        if (mCallback != null) {
             mCallback.onBuffering(percent);
+        }
         if (mSeeker != null) {
-            if (percent == 100) mSeeker.setSecondaryProgress(0);
-            else mSeeker.setSecondaryProgress(mSeeker.getMax() * (percent / 100));
+            if (percent == 100) {
+                mSeeker.setSecondaryProgress(0);
+            } else {
+                float percentage = percent / 100f;
+                int secondaryProgress = (int) (mSeeker.getMax() * percentage);
+                mSeeker.setSecondaryProgress(secondaryProgress);
+            }
         }
     }
 

--- a/library/src/main/java/com/halilibo/bettervideoplayer/BetterVideoPlayer.java
+++ b/library/src/main/java/com/halilibo/bettervideoplayer/BetterVideoPlayer.java
@@ -164,6 +164,7 @@ public class BetterVideoPlayer extends RelativeLayout implements IUserMethods,
     private boolean mShowTotalDuration = false;
     private boolean mAutoPlay;
     private int mInitialPosition = -1;
+    private int mHideControlsDuration = 2000; // defaults to 2 seconds.
     private boolean mControlsDisabled;
 
 
@@ -189,6 +190,7 @@ public class BetterVideoPlayer extends RelativeLayout implements IUserMethods,
                 mPauseDrawable = a.getDrawable(R.styleable.BetterVideoPlayer_bvp_pauseDrawable);
                 mRestartDrawable = a.getDrawable(R.styleable.BetterVideoPlayer_bvp_restartDrawable);
                 mLoadingStyle = a.getInt(R.styleable.SpinKitView_SpinKit_Style, 0);
+                mHideControlsDuration = a.getInteger(R.styleable.BetterVideoPlayer_bvp_hideControlsDuration, mHideControlsDuration);
 
                 mHideControlsOnPlay = a.getBoolean(R.styleable.BetterVideoPlayer_bvp_hideControlsOnPlay, false);
                 mAutoPlay = a.getBoolean(R.styleable.BetterVideoPlayer_bvp_autoPlay, false);
@@ -437,6 +439,10 @@ public class BetterVideoPlayer extends RelativeLayout implements IUserMethods,
         if (isControlsShown()) {
             hideControls();
         } else {
+            if(mHideControlsDuration >= 0) {
+                mHandler.removeCallbacks(hideControlsRunnable);
+                mHandler.postDelayed(hideControlsRunnable, mHideControlsDuration);
+            }
             showControls();
         }
     }

--- a/library/src/main/java/com/halilibo/bettervideoplayer/utility/Util.java
+++ b/library/src/main/java/com/halilibo/bettervideoplayer/utility/Util.java
@@ -15,11 +15,20 @@ import java.util.concurrent.TimeUnit;
 public class Util {
 
     public static String getDurationString(long durationMs, boolean negativePrefix) {
+        long hours = TimeUnit.MILLISECONDS.toHours(durationMs);
+        long minutes = TimeUnit.MILLISECONDS.toMinutes(durationMs);
+        long seconds = TimeUnit.MILLISECONDS.toSeconds(durationMs);
+        if(hours > 0) {
+            return String.format(Locale.getDefault(), "%s%02d:%02d:%02d",
+                    negativePrefix ? "-" : "",
+                    hours,
+                    minutes - TimeUnit.HOURS.toMinutes(hours),
+                    seconds - TimeUnit.MINUTES.toSeconds(minutes));
+        }
         return String.format(Locale.getDefault(), "%s%02d:%02d",
                 negativePrefix ? "-" : "",
-                TimeUnit.MILLISECONDS.toMinutes(durationMs),
-                TimeUnit.MILLISECONDS.toSeconds(durationMs) -
-                        TimeUnit.MINUTES.toSeconds(TimeUnit.MILLISECONDS.toMinutes(durationMs))
+                minutes,
+                seconds - TimeUnit.MINUTES.toSeconds(minutes)
         );
     }
 

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -28,6 +28,7 @@
         <attr name="bvp_hideControlsOnPlay" format="boolean" />
         <attr name="bvp_autoPlay" format="boolean" />
         <attr name="bvp_loop" format="boolean" />
+        <attr name="bvp_showTotalDuration" format="boolean" />
 
         <attr name="bvp_disableControls" format="boolean" />
 

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -29,6 +29,7 @@
         <attr name="bvp_autoPlay" format="boolean" />
         <attr name="bvp_loop" format="boolean" />
         <attr name="bvp_showTotalDuration" format="boolean" />
+        <attr name="bvp_hideControlsDuration" format="integer" />
 
         <attr name="bvp_disableControls" format="boolean" />
 


### PR DESCRIPTION
- Show duration unit for hours.
- Ability to switch between showing the full video length/remaining time.
- Address #8 - fix issue with encoded video URLs crashing the application. 
- Add slide up/down animation to the bottom control. As well as animate the subtitle up and down along with the controls.
- Address #6 - Autohide controls after n seconds (2 seconds by default). If less than 0, then the autohide behaviour is disabled.
- Fix bug with the buffer/secondary progress bar not showing in the seekbar.
- Update gradle version to support instant-run.
